### PR TITLE
CAP361: made the open cti private key not exposed to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
+.env


### PR DESCRIPTION
## Description
Hid open cti private key
## Related Issues
CAP 361
## Testing
Run the whole project with the .env specified
## Checklist
- [x] I have tested my changes locally.
- [ ] I have updated the documentation if necessary.
- [ ] I have added tests if necessary.